### PR TITLE
Fixing a issue with authorimage not being found

### DIFF
--- a/layouts/partials/avatar.html
+++ b/layouts/partials/avatar.html
@@ -1,4 +1,4 @@
 <header class="row text-center header">
-  {{ with .Site.Params.authorimage }} <img src="/img/{{ . }}" alt="Author Image" class="img-circle text-center headshot"> {{ end }}
+  {{ with .Site.Params.authorimage }} <img src="img/{{ . }}" alt="Author Image" class="img-circle text-center headshot"> {{ end }}
   <h1 class="author">{{ .Site.Params.author }}</h1>
 </header>


### PR DESCRIPTION
This happens when using another baseurl then <url>/
For example <url>/blog/