### PR TITLE
Fix: Youtube channel base url

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -78,7 +78,7 @@
   <a href="https://snapchat.com/add/{{.}}" aria-label="Snapchat" target="_blank"><i class="fab fa-snapchat" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.youtube}}
-  <a href="https://youtube.com/c/{{.}}" aria-label="Youtube" target="_blank"><i class="fab fa-youtube" aria-hidden="true"></i></a>
+  <a href="https://youtube.com/channel/{{.}}" aria-label="Youtube" target="_blank"><i class="fab fa-youtube" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.keybase}}
   <a href="https://keybase.io/{{.}}" aria-label="Keybase" target="_blank"><i class="fab fa-keybase" aria-hidden="true"></i></a>


### PR DESCRIPTION
At social, youtube are current using https://www.youtube.com/channel/{channel_id} instead of https://www.youtube.com/c/{channel_id}