### PR TITLE
Add number of minutes to read: list + content

### DIFF
--- a/layouts/partials/content.html
+++ b/layouts/partials/content.html
@@ -6,6 +6,7 @@
   <div class="col-md-12">
     <h6 class="text-left meta">
        {{ if not .Date.IsZero }} PUBLISHED ON {{ .Date.Format .Site.Params.dateformat | upper }} {{end}}
+       / {{ math.Round (div (countwords .Content) 220.0) }} MIN READ
       {{ if isset .Params "categories" }}
       {{ $total := len .Params.categories }}
       {{ if gt $total 0 }}

--- a/layouts/partials/li.html
+++ b/layouts/partials/li.html
@@ -5,6 +5,7 @@
       <a class="list-entry-link" href="{{ .RelPermalink }}">{{ .Title }}</a>
       <p class="meta">
         {{ if not .Date.IsZero }} {{ .Date.Format .Site.Params.dateformat | upper }} {{end}}
+	- {{ math.Round (div (countwords .Content) 220.0) }} MIN READ 
         <span class="category">
         {{ if isset .Params "categories" }}
         {{ $total := len .Params.categories }}


### PR DESCRIPTION
Implement the number of minutes to read, ideas in this [post](https://kodify.net/hugo/strings/reading-time-text/). Add the following line of code after the date in `partial/content.html` and `partial/li.html` to add the feature in each post.

```html
       / {{ math.Round (div (countwords .Content) 220.0) }} MIN READ
```

Preview:

![image](https://user-images.githubusercontent.com/14035919/149946776-a36631ee-7c40-4608-bc70-45edc3f09a91.png)

![image](https://user-images.githubusercontent.com/14035919/149946856-06c22004-de64-4f24-adf4-a63178e8ee4a.png)

