### PR TITLE
Fix the parse error on template: partials/social.html

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -106,6 +106,7 @@
   {{ end }}
   {{ with .Site.Params.social.buymeacoffee}}
   <a href="https://www.buymeacoffee.com//{{.}}" aria-label="Buymeacoffee" target="_blank"><i class="fas fa-coffee" aria-hidden="true"></i></a>
+  {{ end }}
   {{ with .Site.Params.social.kaggle}}
   <a href="https://kaggle.com/{{.}}" aria-label="Kaggle" target="_blank"><i class="fab fa-kaggle" aria-hidden="true"></i></a>
   {{ end }}


### PR DESCRIPTION
First of all, thank you for building this great Hugo template - it's exactly what I need: simple, yet effective. However, I've encountered an issue when cloning the repo and attempting to run on my local development environment:

```
>hugo server -D
Error: add site dependencies: load resources: loading templates: "...\themes\hugo-goa\layouts\partials\social.html:169:1": parse failed: template: partials/social.html:169: unexpected EOF
```

It looks like the recent PR #107  has missed an `{{end}}` statement after [line 108](https://github.com/kaapiandcode/hugo-goa/pull/107/files#diff-9d5c57504f6a5d110cd15f43b77b99342cdb0b84d79dac0583adcabe89ccd624R108), which causes the whole theme not working anymore. This PR attempts to fix this issue.