### PR TITLE
Added mssing {{ end }}

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -106,6 +106,7 @@
   {{ end }}
   {{ with .Site.Params.social.buymeacoffee}}
   <a href="https://www.buymeacoffee.com//{{.}}" aria-label="Buymeacoffee" target="_blank"><i class="fas fa-coffee" aria-hidden="true"></i></a>
+  {{ end }}
   {{ with .Site.Params.social.kaggle}}
   <a href="https://kaggle.com/{{.}}" aria-label="Kaggle" target="_blank"><i class="fab fa-kaggle" aria-hidden="true"></i></a>
   {{ end }}


### PR DESCRIPTION
Added missing {{ end }} in social.html which caused "parse failed: template: partials/social.html:169: unexpected EOF" when compiling the side.