### PR TITLE
Use Analytics without async to work with GA4

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -15,7 +15,7 @@ hljs.initHighlightingOnLoad();
 {{ end }}
 {{ end }}
 
-{{ template "_internal/google_analytics_async.html" . }}
+{{ template "_internal/google_analytics.html" . }}
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 <script src="/js/main.js"></script>


### PR DESCRIPTION
This PR fixes #94.

The async template is not suitable for Google Analytics 4, so I used the other version. (https://gohugo.io/templates/internal/#use-the-google-analytics-template)